### PR TITLE
dontLogBots setting

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -3416,7 +3416,7 @@ function parseCleanContent(content) {
     return content;
 }
 
-if (settings.guilds[message.guild.id].logBots == true){
+if (settings.guilds[message.guild.id].dontLogBots == true){
     if(message.author.bot){
         return
     }

--- a/bot.js
+++ b/bot.js
@@ -2537,9 +2537,9 @@ function getSingleConfigureWelcomeText(guild, author) {
         embed.addField($("CONFIG_NEW_USER_NOTIFICATION_TITLE", {number: "D"}), $("CONFIG_ENABLED"), true);
     }
     if (guildSetting.dontLogBots == null || guildSetting.dontLogBots == false) {
-        embed.addField($("CONFIG_BOT_LOGGING", {number: "D"}), $("CONFIG_ENABLED"), true);
+        embed.addField($("CONFIG_BOT_LOGGING", {number: "E"}), $("CONFIG_ENABLED"), true);
     } else {
-        embed.addField($("CONFIG_BOT_LOGGING", {number: "D"}), $("CONFIG_DISABLED"), true);
+        embed.addField($("CONFIG_BOT_LOGGING", {number: "E"}), $("CONFIG_DISABLED"), true);
     }
 
     embed.setFooter($("CONFIG_FOOTER", {exit: "<", reset: "<<"}));
@@ -2669,10 +2669,10 @@ function processSingleConfigure(message, guild) {
                     message.author.send($("CONFIG_PINTOPIN_TOGGLED", {emoji: consts.config.pinToPinEmoji}));
                     message.author.send(getSingleConfigureWelcomeText(guild, message.author));
                     break;
-                case "c": //dont log bots
+                case "e": //dont log bots
                     guildSetting.dontLogBots = !guildSetting.dontLogBots;
                         
-                    message.author.send($("CONFIG_DONTLOGBOTS_TOGGLED"
+                    message.author.send($("CONFIG_DONTLOGBOTS_TOGGLED"));
                     message.author.send(getSingleConfigureWelcomeText(guild, message.author));
                     break;
                 case ">": //Reset AstralMod

--- a/bot.js
+++ b/bot.js
@@ -3416,6 +3416,12 @@ function parseCleanContent(content) {
     return content;
 }
 
+if (settings.guilds[message.guild.id].logBots == true){
+    if(message.author.bot){
+        return
+    }
+}
+
 function messageDeleted(message) {
     var channel = null;
     if (message.guild != null) {
@@ -3428,11 +3434,7 @@ function messageDeleted(message) {
             }
         }
     }
-    if (settings.guilds[message.guild.id].logBots == true){
-        if(message.author.bot){
-            return
-        }
-    }
+    
 
     if (channel != null) {
         if (settings.guilds[message.guild.id].blocked[message.channel.id].includes("log")) { //If the channel the message was in has logs blocked (or the message was in a log channel, which shouldn't get logged either)

--- a/bot.js
+++ b/bot.js
@@ -3428,6 +3428,11 @@ function messageDeleted(message) {
             }
         }
     }
+    if (settings.guilds[message.guild.id].logBots == true){
+        if(message.author.bot){
+            return
+        }
+    }
 
     if (channel != null) {
         if (settings.guilds[message.guild.id].blocked[message.channel.id].includes("log")) { //If the channel the message was in has logs blocked (or the message was in a log channel, which shouldn't get logged either)

--- a/bot.js
+++ b/bot.js
@@ -3427,13 +3427,13 @@ function parseCleanContent(content) {
     return content;
 }
 
-if (settings.guilds[message.guild.id].dontLogBots == true){
-    if(message.author.bot){
-        return
-    }
-}
 
 function messageDeleted(message) {
+    if (settings.guilds[message.guild.id].dontLogBots == true){
+        if(message.author.bot){
+            return
+        }
+    }  
     var channel = null;
     if (message.guild != null) {
         if (settings.guilds[message.guild.id].chatLogs != null) {

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -546,6 +546,7 @@
     "CONFIG_NICK_MODERATION_TITLE": "**{{number}}** — Nickname requests",
     "CONFIG_FILTERING_TITLE": "**{{number}}** — Expletive filtering",
     "CONFIG_PIN_TO_PIN_TITLE": "**{{number}}** — Pin to pin",
+    "CONFIG_BOT_LOGGING": "**{{number}}** — Bot logging",
     "CONFIG_NEW_USER_NOTIFICATION_TITLE": "**{{number}}** — New user alert",
     "CONFIG_FOOTER": "{{exit}} — Exit Configuration | {{reset}} — Reset {{name}} Settingss",
     "CONFIG_CANCEL_CONFIGURATION": "Returning to main menu.",


### PR DESCRIPTION
added a setting that prevents AstralMod from logging bots if set to true, otherwise it will log bot behavior.