### PR TITLE
Add units for temperature

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -72,9 +72,9 @@ global.shutdown = () => {
 
             process.exit();
         })
+    } else {
+        process.exit();
     }
-
-    process.exit();
 }
 
 process.on("SIGINT", shutdown);

--- a/bot.js
+++ b/bot.js
@@ -62,15 +62,19 @@ global.shutdown = () => {
         
     log("Now exiting AstralMod.", logType.good);
 
-    client.user.setStatus("invisible").then((user) => {
-        try {
-            global.wsServer.closeAllConnections();
-        } catch (ex) {
-            log(ex, logType.warning);
-        }
+    if (client.user !== null) {
+        client.user.setStatus("invisible").then((user) => {
+            try {
+                global.wsServer.closeAllConnections();
+            } catch (ex) {
+                log(ex, logType.warning);
+            }
 
-        process.exit();
-    }).catch(() => process.exit())
+            process.exit();
+        })
+    }
+
+    process.exit();
 }
 
 process.on("SIGINT", shutdown);

--- a/bot.js
+++ b/bot.js
@@ -62,15 +62,17 @@ global.shutdown = () => {
         
     log("Now exiting AstralMod.", logType.good);
 
-    client.user.setStatus("invisible").then((user) => {
-        try {
-            global.wsServer.closeAllConnections();
-        } catch (ex) { 
-            log(ex, logType.warning);
-        }
+    if (client.user !== null) {
+        client.user.setStatus("invisible").then((user) => {
+            try {
+                global.wsServer.closeAllConnections();
+            } catch (ex) {
+                log(ex, logType.warning);
+            }
+        })
+    }
 
-        process.exit();
-    })
+    process.exit();
 }
 
 process.on("SIGINT", shutdown);

--- a/bot.js
+++ b/bot.js
@@ -62,17 +62,15 @@ global.shutdown = () => {
         
     log("Now exiting AstralMod.", logType.good);
 
-    if (client.user !== null) {
-        client.user.setStatus("invisible").then((user) => {
-            try {
-                global.wsServer.closeAllConnections();
-            } catch (ex) {
-                log(ex, logType.warning);
-            }
-        })
-    }
+    client.user.setStatus("invisible").then((user) => {
+        try {
+            global.wsServer.closeAllConnections();
+        } catch (ex) {
+            log(ex, logType.warning);
+        }
 
-    process.exit();
+        process.exit();
+    }).catch(() => process.exit())
 }
 
 process.on("SIGINT", shutdown);

--- a/plugins/misc.js
+++ b/plugins/misc.js
@@ -66,6 +66,15 @@ function processCommand(message, isMod, command, options) {
         } else if (units.toLowerCase() === "24" || units.toLowerCase() === "24h" || units.toLowerCase() === "24hr") {
             settings.users[message.author.id].timeunit = "24h";
             message.reply($("SETUNIT_24"));
+        } else if (units.toLowerCase() === "celsius") {
+            settings.users[message.author.id].temperatureunit = "celsius";
+            message.reply($("SETUNIT_CELSIUS"));
+        } else if (units.toLowerCase() === "fahrenheit") {
+            settings.users[message.author.id].temperatureunit = "fahrenheit";
+            message.reply($("SETUNIT_FAHRENHEIT"));
+        } else if (units.toLowerCase() === "kelvin") {
+            settings.users[message.author.id].temperatureunit = "kelvin";
+            message.reply($("SETUNIT_KELVIN"));
         } else {
             throw new UserInputError($("SETUNIT_INVALID_UNIT"));
         }

--- a/plugins/misc.js
+++ b/plugins/misc.js
@@ -1,7 +1,7 @@
 /****************************************
  * 
  *   Miscellaneous: Plugin for AstralMod that contains miscellaneous commands
- *   Copyright (C) 2019 Victor Tran, John Tur
+ *   Copyright (C) 2019 Victor Tran, John Tur and Mart Koster
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/plugins/weather.js
+++ b/plugins/weather.js
@@ -182,6 +182,32 @@ function getDataFromCode(code, ctx, $) {
     }
 }
 
+function convertTemperatureUnit(celsius, target, decimalpoints = 0) {
+    let result;
+    switch (target) {
+        case "fahrenheit":
+            result = celsius * 1.8 + 32;
+            break;
+        case "kelvin":
+            result = celsius + 273.15;
+            break;
+        default:
+            result = celsius;
+    }
+    return result.toFixed(decimalpoints);
+}
+
+function getTemperatureUnitSymbol(unit) {
+    switch (unit) {
+        case "fahrenheit":
+            return " °F"
+        case "kelvin":
+            return " K"
+        default:
+            return " °C"
+    }
+}
+
 function sendCurrentWeather(message, location, type, options, user = "", skiiness = false) {
     let $ = _[options.locale];
     sendPreloader($("WEATHER_PREPARING"), message.channel).then(messageToEdit => {
@@ -262,7 +288,7 @@ function sendCurrentWeather(message, location, type, options, user = "", skiines
 
                 fill = fills[display.background];
 
-                let tempUnit = "°C";
+                let tempUnit = settings.users[message.author.id].temperatureunit;
                 let speedUnit = "km/h";
 
                 ctx.fillStyle = fill.primary;
@@ -371,7 +397,7 @@ function sendCurrentWeather(message, location, type, options, user = "", skiines
                 }
 
                 ctx.font = "30px Contemporary";
-                let currentTemp = (currentWeather.hasOwnProperty("temperature") ? currentWeather.temperature.value : "---") + tempUnit;
+                let currentTemp = (currentWeather.hasOwnProperty("temperature") ? convertTemperatureUnit(parseFloat(currentWeather.temperature.value), tempUnit, 1) : "---") + getTemperatureUnitSymbol(tempUnit);
                 let tempWidth = ctx.measureText(currentTemp);
                 ctx.fillText(currentTemp, 175 - tempWidth.width / 2, 315);
 
@@ -508,8 +534,9 @@ function sendCurrentWeather(message, location, type, options, user = "", skiines
                     ctx.drawImage(display.icon, 380, (current - 1) * 82 + 9, 64, 64);
 
                     //Draw temperatures
-                    ctx.fillText((data.hasOwnProperty("maxTemperature") ? parseFloat(data.maxTemperature.value).toFixed() : "---") + "°", 450, (current - 1) * 82 + 30);
-                    ctx.fillText((data.hasOwnProperty("minTemperature") ? parseFloat(data.minTemperature.value).toFixed() : "---") + "°", 450, (current - 1) * 82 + 60);
+                    let tempUnit = settings.users[message.author.id].temperatureunit;
+                    ctx.fillText((data.hasOwnProperty("maxTemperature") ? convertTemperatureUnit(parseFloat(data.maxTemperature.value), tempUnit) : "---") + getTemperatureUnitSymbol(tempUnit), 450, (current - 1) * 82 + 30);
+                    ctx.fillText((data.hasOwnProperty("minTemperature") ? convertTemperatureUnit(parseFloat(data.minTemperature.value), tempUnit) : "---") + getTemperatureUnitSymbol(tempUnit), 450, (current - 1) * 82 + 60);
 
                     ctx.beginPath();
                     ctx.moveTo(350, current * 82);

--- a/plugins/weather.js
+++ b/plugins/weather.js
@@ -1,7 +1,7 @@
 /****************************************
  * 
  *   Weather: Plugin for AstralMod that contains weather functions
- *   Copyright (C) 2019 Victor Tran, John Tur, zBlake and lempamo
+ *   Copyright (C) 2019 Victor Tran, John Tur, zBlake, lempamo and Mart Koster
  *
  *   This program is free software: you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by

--- a/translations/en/help.json
+++ b/translations/en/help.json
@@ -54,7 +54,7 @@
     "PIC_HELPTEXT": "Gets someone's profile picture",
     "PIC_PARAM1": "*Optional Parameter*\nThe user that you want to get the profile picture of. If no user is specified, your profile picture will be returned",
     "SETUNIT_HELPTEXT": "Sets the units that you prefer {{name}} to use",
-    "SETUNIT_PARAM1": "Either `metric`, `imperial`, `24(hr)`, or `12(hr)`",
+    "SETUNIT_PARAM1": "Either `metric`, `imperial`, `24(hr)`, `12(hr)`, `celsius`, `fahrenheit` or `kelvin`",
     "SETUNIT_REMARKS": "If you want to set the language that you prefer {{name}} to use, use {{prefix}}setlocale.",
     "SINFO_HELPTEXT": "Retrieves miscellaneous information about the current server",
     "CALC_HELPTEXT": "Invokes theCalculator and calculates mathematical expressions",

--- a/translations/en/translation.json
+++ b/translations/en/translation.json
@@ -350,10 +350,14 @@
     
     "SETUNIT_IMPERIAL": "OK, we'll use the imperial system for your units from now on",
     "SETUNIT_METRIC": "OK, we'll use the metric system for your units from now on",
-    "SETUNIT_INVALID_UNIT": "Units need to be `metric`, `imperial`, `12h` or `24h`",
+    "SETUNIT_INVALID_UNIT": "Units need to be `metric`, `imperial`, `12h`, `24h`, `celsius`, `fahrenheit` or `kelvin`",
 
     "SETUNIT_12": "OK, we'll use 12 hours for your time from now on",
     "SETUNIT_24": "OK, we'll use 24 hours for your time from now on",
+
+    "SETUNIT_CELSIUS": "OK, we'll use Celsius for your temperature from now on",
+    "SETUNIT_FAHRENHEIT": "OK, we'll use Fahrenheit for your temperature from now on",
+    "SETUNIT_KELVIN": "OK, we'll use Kelvin for your temperature from now on",
     
     "SHOO_NO_PERMS": "Only people who have kicking permissions can use this command.",
     "SHOO_TITLE": "Kicking {{name}} :(",


### PR DESCRIPTION
This PR adds Fahrenheit and Kelvin as temperature units for the `am:weather` command.

The temperature unit is set in the settings database as a new property `temperatureunit` and can be set through `am:setunit`. I've modified the source for translations so they include the new messages for `am:setunit`.

The `am:weather` command will convert the temperature to the preferred unit if it's not celsius. If no unit has been set by the user, it will use degrees Celsius by default.

While I was working on this thing, I also fixed a small bug that caused AstralMod not to be able to stop if it couldn't connect to Discord on startup.